### PR TITLE
Fix example formatting and remove inline attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,70 +43,68 @@ performance as long as you don't run into some of the slower fallback functions.
 # Example
 
 ```rust
-    // If using runtime feature detection, you will want to be sure this inlines
-    // so you can leverage target_feature attributes
-    #[inline(always)]
-    unsafe fn distance<S: Simd>(
-        x1: &[f32], 
-        y1: &[f32], 
-        x2: &[f32], 
-        y2: &[f32]) -> Vec<f32> {
+unsafe fn distance<S: Simd>(
+    x1: &[f32], 
+    y1: &[f32], 
+    x2: &[f32], 
+    y2: &[f32]) -> Vec<f32> {
 
-        let mut result: Vec<f32> = Vec::with_capacity(x1.len());
-        result.set_len(x1.len()); // for efficiency
+    let mut result: Vec<f32> = Vec::with_capacity(x1.len());
+    result.set_len(x1.len()); // for efficiency
 
-        // Operations have to be done in terms of the vector width
-        // so that it will work with any size vector.
-        // the width of a vector type is provided as a constant
-        // so the compiler is free to optimize it more.
-        let mut i = 0;
-        //S::VF32_WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
-        while i < x1.len() {
-            //load data from your vec into a SIMD value
-            let xv1 = S::loadu_ps(&x1[i]);
-            let yv1 = S::loadu_ps(&y1[i]);
-            let xv2 = S::loadu_ps(&x2[i]);
-            let yv2 = S::loadu_ps(&y2[i]);
+    // Operations have to be done in terms of the vector width
+    // so that it will work with any size vector.
+    // the width of a vector type is provided as a constant
+    // so the compiler is free to optimize it more.
+    let mut i = 0;
+    //S::VF32_WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
+    while i < x1.len() {
+        //load data from your vec into a SIMD value
+        let xv1 = S::loadu_ps(&x1[i]);
+        let yv1 = S::loadu_ps(&y1[i]);
+        let xv2 = S::loadu_ps(&x2[i]);
+        let yv2 = S::loadu_ps(&y2[i]);
 
-            // Use the usual intrinsic syntax if you prefer
-            let mut xdiff = S::sub_ps(xv1, xv2);
-            // Or use operater overloading if you like
-            let mut ydiff = yv1 - yv2;
-            xdiff *= xdiff;
-            ydiff *= ydiff;
-            let distance = S::sqrt_ps(xdiff + ydiff);
-            // Store the SIMD value into the result vec
-            S::storeu_ps(&mut result[i], distance);
-            // Increment i by the vector width
-            i += S::VF32_WIDTH
-        }
-        result
+        // Use the usual intrinsic syntax if you prefer
+        let mut xdiff = S::sub_ps(xv1, xv2);
+        // Or use operater overloading if you like
+        let mut ydiff = yv1 - yv2;
+        xdiff *= xdiff;
+        ydiff *= ydiff;
+        let distance = S::sqrt_ps(xdiff + ydiff);
+        // Store the SIMD value into the result vec
+        S::storeu_ps(&mut result[i], distance);
+        // Increment i by the vector width
+        i += S::VF32_WIDTH
     }
+    result
+}
 
-    //Call distance as an SSE2 function
-    #[target_feature(enable = "sse2")]
-    unsafe fn distance_sse2(
-        x1: &[f32], 
-        y1: &[f32], 
-        x2: &[f32], 
-        y2: &[f32]) -> Vec<f32> {
-        distance::<Sse2>(x1, y1, x2, y2)
-    }
-    //Call distance as an SSE41 function
-    #[target_feature(enable = "sse4.1")]
-    unsafe fn distance_sse41(
-        x1: &[f32], 
-        y1: &[f32], 
-        x2: &[f32], 
-        y2: &[f32]) -> Vec<f32> {
-        distance::<Sse41>(x1, y1, x2, y2)
-    }
-    //Call distance as an AVX2 function
-    #[target_feature(enable = "avx2")]
-    unsafe fn distance_avx2(
-        x1: &[f32], 
-        y1: &[f32], 
-        x2: &[f32], 
-        y2: &[f32]) -> Vec<f32> {
-        distance::<Avx2>(x1, y1, x2, y2)
-    }```
+//Call distance as an SSE2 function
+#[target_feature(enable = "sse2")]
+unsafe fn distance_sse2(
+    x1: &[f32], 
+    y1: &[f32], 
+    x2: &[f32], 
+    y2: &[f32]) -> Vec<f32> {
+    distance::<Sse2>(x1, y1, x2, y2)
+}
+//Call distance as an SSE41 function
+#[target_feature(enable = "sse4.1")]
+unsafe fn distance_sse41(
+    x1: &[f32], 
+    y1: &[f32], 
+    x2: &[f32], 
+    y2: &[f32]) -> Vec<f32> {
+    distance::<Sse41>(x1, y1, x2, y2)
+}
+//Call distance as an AVX2 function
+#[target_feature(enable = "avx2")]
+unsafe fn distance_avx2(
+    x1: &[f32], 
+    y1: &[f32], 
+    x2: &[f32], 
+    y2: &[f32]) -> Vec<f32> {
+    distance::<Avx2>(x1, y1, x2, y2)
+}
+```


### PR DESCRIPTION
`target_feature` attributes work independently of inline attributes, and `#[inline(always)]` just forces LLVM to inline calls even in debug mode.

Also it would be great if the example would explain why all the functions are marked as `unsafe`.