### PR TITLE
Changed examples and test to use more efficient iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ use simdeez::*;
     use simdeez::scalar::*;
     use simdeez::sse2::*;
     use simdeez::sse41::*;
-    use simdeez::avx::*;
     use simdeez::avx2::*;
     // If you want your SIMD function to use use runtime feature detection to call
     // the fastest available version, use the simd_runtime_generate macro:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ use simdeez::*;
     use simdeez::scalar::*;
     use simdeez::sse2::*;
     use simdeez::sse41::*;
+    use simdeez::avx::*;
     use simdeez::avx2::*;
     // If you want your SIMD function to use use runtime feature detection to call
     // the fastest available version, use the simd_runtime_generate macro:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,22 +62,29 @@
 //!         y1: &[f32],
 //!         x2: &[f32],
 //!         y2: &[f32]) -> Vec<f32> {
-//!
+//! 
 //!         let mut result: Vec<f32> = Vec::with_capacity(x1.len());
 //!         result.set_len(x1.len()); // for efficiency
-//!
+//!         
+//!         /// Set each slice to the same length for iteration efficiency
+//!         let mut x1 = &x1[..x1.len()];
+//!         let mut y1 = &y1[..x1.len()];
+//!         let mut x2 = &x2[..x1.len()];
+//!         let mut y2 = &y2[..x1.len()];
+//!         let mut res = &mut result[..x1.len()];
+//! 
 //!         // Operations have to be done in terms of the vector width
 //!         // so that it will work with any size vector.
 //!         // the width of a vector type is provided as a constant
 //!         // so the compiler is free to optimize it more.
 //!         // S::VF32_WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
-//!         for i in (0..x1.len()).step_by(S::VF32_WIDTH) {
-//!             //load data from your vec into a SIMD value
-//!             let xv1 = S::loadu_ps(&x1[i]);
-//!             let yv1 = S::loadu_ps(&y1[i]);
-//!             let xv2 = S::loadu_ps(&x2[i]);
-//!             let yv2 = S::loadu_ps(&y2[i]);
-//!
+//!         while x1.len() >= S::VF32_WIDTH {
+//!             //load data from your vec into an SIMD value
+//!             let xv1 = S::loadu_ps(&x1[0]);
+//!             let yv1 = S::loadu_ps(&y1[0]);
+//!             let xv2 = S::loadu_ps(&x2[0]);
+//!             let yv2 = S::loadu_ps(&y2[0]);
+//! 
 //!             // Use the usual intrinsic syntax if you prefer
 //!             let mut xdiff = S::sub_ps(xv1, xv2);
 //!             // Or use operater overloading if you like
@@ -86,8 +93,28 @@
 //!             ydiff *= ydiff;
 //!             let distance = S::sqrt_ps(xdiff + ydiff);
 //!             // Store the SIMD value into the result vec
-//!             S::storeu_ps(&mut result[i], distance);
+//!             S::storeu_ps(&mut res[0], distance);
+//!             
+//!             // Move each slice to the next position
+//!             x1 = &x1[S::VF32_WIDTH..];
+//!             y1 = &y1[S::VF32_WIDTH..];
+//!             x2 = &x2[S::VF32_WIDTH..];
+//!             y2 = &y2[S::VF32_WIDTH..];
+//!             res = &mut res[S::VF32_WIDTH..];
 //!         }
+//!         
+//!         // (Optional) Compute the remaining elements. Not necessary if you are sure the length
+//!         // of your data is always a multiple of the maximum S::VF32_WIDTH you compile for (4 for SSE, 8 for AVX2, etc).
+//!         // This can be asserted using `assert_eq!(x1.len() % S::VF32_WIDTH, 0);`
+//!         for i in 0..x1.len() {
+//!             let mut xdiff = x1[i] - x2[i];
+//!             let mut ydiff = y1[i] - y2[i];
+//!             xdiff *= xdiff;
+//!             ydiff *= ydiff;
+//!             let distance = (xdiff + ydiff).sqrt();
+//!             res[i] = distance;
+//!         }
+//!         
 //!         result
 //!     });
 //! # fn main() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -43,7 +43,7 @@ mod tests {
             ydiff *= ydiff;
             let distance = S::sqrt_ps(xdiff + ydiff);
             // Store the SIMD value into the result vec
-            S::storeu_ps(&mut result[i], distance);
+            S::storeu_ps(&mut res[0], distance);
             
             // Move each slice to the next position
             x1 = &x1[S::VF32_WIDTH..];

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,19 +15,25 @@ mod tests {
     unsafe fn distance<S: Simd>(x1: &[f32], y1: &[f32], x2: &[f32], y2: &[f32]) -> Vec<f32> {
         let mut result: Vec<f32> = Vec::with_capacity(x1.len());
         result.set_len(x1.len()); // for efficiency
+        
+        /// Set each slice to the same length for iteration efficiency
+        let mut x1 = &x1[..x1.len()];
+        let mut y1 = &y1[..x1.len()];
+        let mut x2 = &x2[..x1.len()];
+        let mut y2 = &y2[..x1.len()];
+        let mut res = &mut result[..x1.len()];
 
         // Operations have to be done in terms of the vector width
         // so that it will work with any size vector.
         // the width of a vector type is provided as a constant
         // so the compiler is free to optimize it more.
-        let mut i = 0;
         //S::VF32_WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
-        while i < x1.len() {
+        while x1.len() >= S::VF32_WIDTH {
             //load data from your vec into a SIMD value
-            let xv1 = S::loadu_ps(&x1[i]);
-            let yv1 = S::loadu_ps(&y1[i]);
-            let xv2 = S::loadu_ps(&x2[i]);
-            let yv2 = S::loadu_ps(&y2[i]);
+            let xv1 = S::loadu_ps(&x1[0]);
+            let yv1 = S::loadu_ps(&y1[0]);
+            let xv2 = S::loadu_ps(&x2[0]);
+            let yv2 = S::loadu_ps(&y2[0]);
 
             // Use the usual intrinsic syntax if you prefer
             let mut xdiff = S::sub_ps(xv1, xv2);
@@ -38,8 +44,13 @@ mod tests {
             let distance = S::sqrt_ps(xdiff + ydiff);
             // Store the SIMD value into the result vec
             S::storeu_ps(&mut result[i], distance);
-            // Increment i by the vector width
-            i += S::VF32_WIDTH
+            
+            // Move each slice to the next position
+            x1 = &x1[S::VF32_WIDTH..];
+            y1 = &y1[S::VF32_WIDTH..];
+            x2 = &x2[S::VF32_WIDTH..];
+            y2 = &y2[S::VF32_WIDTH..];
+            res = &mut res[S::VF32_WIDTH..];
         }
         result
     }


### PR DESCRIPTION
If it is possible, it may be nice to create macro helpers later to make it quicker to set slices to the same length and to move them at the end of each loop.