### PR TITLE
release: bump to 3.0.1 and re-expose engines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simdeez"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Jack Mott <jack.mott@gmail.com>", "Arduano"]
 description = "SIMD library to abstract over different instruction sets and widths"
 license = "Apache-2.0/MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ mod libm_ext;
 pub mod math;
 pub use math::{SimdMathF32, SimdMathF64};
 
-mod engines;
+pub mod engines;
 
 pub use engines::scalar;
 


### PR DESCRIPTION
## Summary
- bump crate version from 3.0.0 to 3.0.1
- re-expose `simdeez::engines` as a public module again

## Why
A downstream user reported that making `engines` private in 3.0.0 broke their extension pattern (`impl Trait for Avx2`/etc with backend-specific intrinsics and vector constructors). This patch restores that public surface while keeping the rest of 3.0 changes intact.